### PR TITLE
Actualización de ruta/nombre para ubuntu 14.04

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -13,7 +13,7 @@ sudo apt-get install libdvdcss2
 # Apache and PHP
 sudo apt-get install -y apache2 php5-mysql libapache2-mod-php5 mysql-client-5.5 mysql-server php-pear mailutils postfix
 sudo apt-get install -y php5-xsl php5-gd php5-curl php5-json
-sudo sh -c 'echo "ServerName localhost" >> /etc/apache2/conf.d/name' && sudo service apache2 restart
+sudo sh -c 'echo "ServerName localhost" >> /etc/apache2/conf-available/name.conf' && a2enconf name && sudo service apache2 restart
 
 # Programming tools
 sudo pear channel-update pear.php.net


### PR DESCRIPTION
En ubuntu 14.04 los ficheros de configuración deben tener la forma ficher.conf, además se han cambiado los directorios.
